### PR TITLE
Renamed from vibrate to flutter_vibrate in a few locations to fix iOS…

### DIFF
--- a/ios/Classes/VibratePlugin.m
+++ b/ios/Classes/VibratePlugin.m
@@ -1,5 +1,5 @@
 #import "VibratePlugin.h"
-#import <vibrate/vibrate-Swift.h>
+#import <flutter_vibrate/flutter_vibrate-Swift.h>
 
 @implementation VibratePlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {

--- a/ios/flutter_vibrate.podspec
+++ b/ios/flutter_vibrate.podspec
@@ -2,7 +2,7 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
 Pod::Spec.new do |s|
-  s.name             = 'vibrate'
+  s.name             = 'flutter_vibrate'
   s.version          = '0.0.1'
   s.summary          = 'A new Flutter plugin.'
   s.description      = <<-DESC


### PR DESCRIPTION
… build

Before these changes, the iOS build failed with the following error:
```
Fetching podspec for `flutter_vibrate` from `.symlinks/plugins/flutter_vibrate/ios`
[!] No podspec found for `flutter_vibrate` in `.symlinks/plugins/flutter_vibrate/ios`
```