### PR TITLE
use google() maven for better network accessibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,9 +4,7 @@ version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
     }
 
     dependencies {
@@ -17,9 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
     }
 }
 


### PR DESCRIPTION
According to [gradle issue #2151](https://github.com/gradle/gradle/issues/2151), https://maven.google.com is blocked in china, use google() instead.


Currently, we are suffering from this issue in china😂

