### PR TITLE
added namespace property for gradle 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace "flutter.plugins.vibrate"
     compileSdkVersion 30
 
     defaultConfig {


### PR DESCRIPTION
Getting this issue when upgrading to gradle 8 for my project (Android)
`
A problem occurred configuring project ':flutter_vibrate'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

`