### PR TITLE
namespace is automatically specified as required

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,4 +35,9 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    if (project.android.hasProperty("namespace")) {
+        namespace 'flutter.plugins.vibrate'
+    }
+
 }


### PR DESCRIPTION
To fix namespace not specified. Specify a namespace in the module's build file.