### PR TITLE
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="flutter.plugins.vibrate">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.

Log terminal:
```
Incorrect package="flutter.plugins.vibrate" found in source AndroidManifest.xml: /Users/longtn/.pub-cache/hosted/pub.dev/flutter_vibrate-1.3.0/android/src/main/AndroidManifest.xml.
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.
Recommendation: remove package="flutter.plugins.vibrate" from the source AndroidManifest.xml: /Users/longtn/.pub-cache/hosted/pub.dev/flutter_vibrate-1.3.0/android/src/main/AndroidManifest.xml.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':flutter_vibrate:processDebugManifest'.
> A failure occurred while executing com.android.build.gradle.tasks.ProcessLibraryManifest$ProcessLibWorkAction
   > Incorrect package="flutter.plugins.vibrate" found in source AndroidManifest.xml: /Users/longtn/.pub-cache/hosted/pub.dev/flutter_vibrate-1.3.0/android/src/main/AndroidManifest.xml.
     Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.
     Recommendation: remove package="flutter.plugins.vibrate" from the source AndroidManifest.xml: /Users/longtn/.pub-cache/hosted/pub.dev/flutter_vibrate-1.3.0/android/src/main/AndroidManifest.xml.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 17m 10s
Error: Gradle task assembleDevDebug failed with exit code 1
```