### PR TITLE
Fixes Xcode 16.3 error: Cannot find 'TARGET_OS_SIMULATOR' in scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+* Fixes Xcode 16.3 compilation error: "Swift Compiler Error (Xcode): Cannot find 'TARGET_OS_SIMULATOR' in scope" 
+
 ## 1.3.0
 
 * Fixing swift version

--- a/ios/Classes/SwiftVibratePlugin.swift
+++ b/ios/Classes/SwiftVibratePlugin.swift
@@ -2,8 +2,6 @@ import Flutter
 import UIKit
 import AudioToolbox
 
-private let isDevice = TARGET_OS_SIMULATOR == 0
-    
 public class SwiftVibratePlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "vibrate", binaryMessenger: registrar.messenger())
@@ -14,11 +12,11 @@ public class SwiftVibratePlugin: NSObject, FlutterPlugin {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
       switch (call.method) {
           case "canVibrate":
-              if isDevice {
-                result(true)
-              } else {
-                result(false)
-              }
+#if targetEnvironment(simulator)
+            result(false)
+#else
+            result(true)
+#endif
           case "vibrate":
             AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
             // Feedback

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_vibrate
 description: A Haptic Feedback plugin.
-version: 1.3.0
+version: 1.3.1
 environment:
   sdk: '>=2.12.0 <3.0.0'
   flutter: ^1.10.0


### PR DESCRIPTION
Solves Swift compilation error when using Xcode 16.3.

Swift error:
> SwiftVibratePlugin.swift:5:24: Cannot find 'TARGET_OS_SIMULATOR' in scope

Screenshot of error:

<img width="733" alt="image" src="https://github.com/user-attachments/assets/60f613bc-d29b-4b5f-b6bc-59e397f184ee" />


